### PR TITLE
Updates golang toolchain to version 1.23.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/protodoc
 
 go 1.23
 
-toolchain go1.23.6
+toolchain go1.23.7
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
Updating golang toolchain to version 1.23.7

Subtask from https://github.com/etcd-io/etcd/issues/19524

Verified with

```
make test