### PR TITLE
Bump go toolchain to v1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/protodoc
 
 go 1.23
 
-toolchain go1.23.7
+toolchain go1.23.8
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
Reference https://github.com/etcd-io/etcd/issues/19713