### PR TITLE
Bump Go to 1.23.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/protodoc
 
 go 1.23
 
-toolchain go1.23.9
+toolchain go1.23.10
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
Part of: https://github.com/etcd-io/etcd/issues/20126