### PR TITLE
Bump go to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/protodoc
 
 go 1.24
 
-toolchain go1.24.8
+toolchain go1.24.9
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
ref: https://github.com/etcd-io/etcd/issues/20799