### PR TITLE
Bump go version to 1.25.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.etcd.io/protodoc
 
-go 1.24
+go 1.25
 
-toolchain go1.24.13
+toolchain go1.25.7
 
 require github.com/spf13/cobra v1.9.1
 


### PR DESCRIPTION
Reference:
- https://github.com/etcd-io/etcd/issues/21364